### PR TITLE
Update index.htm - organic sugar export from India and Philippines.

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -5,7 +5,7 @@
     <p>
       Every cookie made at the Kevin Cookie company is crafted with only the
       best ingredients. Butter from grass fed cows. Unbleached flour with the
-      best flavor and textures. Organic sugar only from India. Even our water is
+      best flavor and textures. Organic sugar from India and Phillippines. Even our water is
       special. It comes from the Cascade Mountain springs that we hike up to
       retrieve. Baking is our passion and we take it very seriously.
     </p>


### PR DESCRIPTION
Earlier the organic sugar was imported from India only. Now we have two countries in option.(India and Philippines)